### PR TITLE
等号否定の一方に空文字列を割り当てることで充足可能な制約を充足不可能だと判定するバグを修正

### DIFF
--- a/constraints/bench/split_concat.smt2
+++ b/constraints/bench/split_concat.smt2
@@ -1,0 +1,14 @@
+(declare-const x String)
+(declare-const y String)
+(declare-const z String)
+(declare-const w String)
+(declare-const i Int)
+
+(assert (= y (str.substr x 0 i)))
+(assert (= z (str.substr x i (- (str.len x) i))))
+(assert (= w (str.++ y z)))
+
+(assert (not (= x w)))
+
+(check-sat)
+(get-model)

--- a/src/main/scala/Operation.scala
+++ b/src/main/scala/Operation.scala
@@ -25,6 +25,7 @@ object Operation {
 }
 
 trait IntValuedOperation extends Operation {
+
   /**
     * この操作 f が i = f(x, i1, ..., in) のように使われているとき，
     * x \in Lang(i, i1, ..., in) がこの等式と等価になるような言語．
@@ -262,14 +263,14 @@ object IntValuedOperation {
           alphabet.flatMap { a =>
             Iterable(
               (q0, a, Map(0 -> 1, 1 -> 1, 2 -> 0), q0),
-              (q0, a, Map(0 -> 1, 1 -> 0, 2 -> a.toInt), qf),
+              (q0, a, Map(0 -> 1, 1 -> 0, 2 -> (a.toInt + 1)), qf),
               (qf, a, Map(0 -> 1, 1 -> 0, 2 -> 0), qf)
             )
           },
           q0,
-          Set((q0, Map(0 -> 0, 1 -> 0, 2 -> -1)), (qf, Map(0 -> 0, 1 -> 0, 2 -> 0))),
+          Set((q0, Map(0 -> 0, 1 -> 0, 2 -> 0)), (qf, Map(0 -> 0, 1 -> 0, 2 -> 0))),
           binding ++ Seq(
-            (i >= 0 && i < input) ==> (i === index && c === code),
+            (i >= 0 && i < input) ==> (i === index && c + 1 === code),
             (i < 0 || input <= i) ==> (c === -1)
           )
         )

--- a/src/main/scala/machine/ParikhAutomaton.scala
+++ b/src/main/scala/machine/ParikhAutomaton.scala
@@ -14,6 +14,11 @@ case class ParikhAutomaton[Q, A, L, I](
     acceptFormulas: Seq[Presburger.Formula[Either[I, L]]]
 ) {
 
+  // Require that all vectors be positive.
+  // This will not change expressivenes
+  //  and might make satisfiability checking simpler.
+  require(edges.forall { case (_, _, v, _) => v.forall { case (_, n) => n >= 0 } })
+
   lazy val sizes = (states.size, edges.size)
 
   val trans = graphToMap(edges) { case (q, a, v, r)         => (q, a) -> (r, v) }

--- a/src/test/scala/ParikhSolverTest.scala
+++ b/src/test/scala/ParikhSolverTest.scala
@@ -381,6 +381,15 @@ trait ConstraintTestCases extends TestsSAT {
     val x = m("x")
     assert(x == "aaaaabbbbb")
   }
+
+  testFileSAT("split_concat") { (sm, im) =>
+    val Seq(x, y, z, w) = Seq("x", "y", "z", "w").map(sm)
+    val i = im("i")
+    assert(y == x.atmostSubstring(0, i))
+    assert(z == x.atmostSubstring(i, x.length - i))
+    assert(w == y ++ z)
+  }
+
 }
 
 class JSSST2021StrategyTest extends AnyFunSuite with ConstraintTestCases with UsesJSSST


### PR DESCRIPTION
Parikh オートマトンから線形算術論理式へ充足可能性を変換するアルゴリズムは、遷移のラベルとして現れるベクトルの要素が非負であることを仮定していた。しかし `code_at` から構成されるオートマトンはこの条件を満たしていなかったため、以下をすべて満たす制約が正しく解けなかった。

* 文字列間の等号否定を含む
* 等号否定の一方の辺に空文字列を割り当てる解が存在する
* それ以外の場合は充足されない

この PR は `code_at` に対応するオートマトンの構成を修正する。