### PR TITLE
線形算術論理式の構成に全称量化子を使えるようにする

### DIFF
--- a/constraints/bench/forall.smt2
+++ b/constraints/bench/forall.smt2
@@ -1,0 +1,10 @@
+(declare-const x String)
+
+(assert (forall ((i Int)) (=> (< i 3) (< i (str.len x)))))
+(assert (forall ((i Int)) (=> (> i 3) (> i (str.len x)))))
+;; (assert (forall ((i Int)) (= (str.code_at x (+ i 1)) 97))) ; should raise an exception
+
+(assert (str.in.re x (re.+ (str.to.re "a"))))
+
+(check-sat)
+(get-model)

--- a/constraints/bench/prime-sat.smt2
+++ b/constraints/bench/prime-sat.smt2
@@ -1,0 +1,12 @@
+(declare-const x String)
+(declare-const l Int)
+
+;; length of x is prime
+(assert (forall ((i Int)) (=> (and (> i 1) (< i l)) (> (mod l i) 0))))
+(assert (= (str.len x) l))
+(assert (> l 7))
+
+(assert (str.in.re x (re.++ (re.+ (str.to.re "ab")) (str.to.re "a"))))
+
+(check-sat)
+(get-model)

--- a/constraints/bench/test-forall-1.smt2
+++ b/constraints/bench/test-forall-1.smt2
@@ -1,0 +1,4 @@
+(declare-const x Int)
+(declare-const y String)
+(assert (forall ((x Int)) (= x 0)))
+(check-sat)

--- a/constraints/bench/test-forall-2.smt2
+++ b/constraints/bench/test-forall-2.smt2
@@ -1,0 +1,6 @@
+(declare-const x String)
+(declare-const i Int)
+
+(assert (forall ((ui Int)) (= ui i)))
+
+(check-sat)

--- a/src/main/scala/Operation.scala
+++ b/src/main/scala/Operation.scala
@@ -54,6 +54,7 @@ object Operation {
       case Ints.Add(t1, t2) => aux(Seq(t1, t2))
       case Ints.Sub(t1, t2) => aux(Seq(t1, t2))
       case Ints.Mul(t1, t2) => aux(Seq(t1, t2))
+      case Ints.Mod(t1, t2) => aux(Seq(t1, t2))
       // string-valued
       case Strings.Concat(ts @ _*)        => aux(ts)
       case Strings.At(t1, t2)             => aux(Seq(t1, t2))

--- a/src/main/scala/Operation.scala
+++ b/src/main/scala/Operation.scala
@@ -11,6 +11,7 @@ import com.github.kmn4.expresso.smttool.Strings
 import smtlib.theories.Ints
 import smtlib.trees.Terms
 import smtlib.trees.Terms.SNumeral
+import com.github.kmn4.expresso.smttool.BottomUpTermTransformer
 
 // Parikh オートマトンや Parikh SST で表して扱う文字列操作．
 sealed trait Operation {
@@ -22,6 +23,56 @@ sealed trait Operation {
 
 object Operation {
   val builtins: Seq[Operation] = IntValuedOperation.builtins ++ StringValuedOperation.builtins
+
+  private val strOps: PartialFunction[Terms.Term, Terms.Sort] = {
+    case Strings.Concat(_*)          => Strings.StringSort()
+    case Strings.At(_, _)            => Strings.StringSort()
+    case Strings.Replace(_, _, _)    => Strings.StringSort()
+    case Strings.Substring(_, _, _)  => Strings.StringSort()
+    case Strings.ReplaceAll(_, _, _) => Strings.StringSort()
+  }
+  // まだ StringValuedOperation.builtins が実装されていないので strOps が必要
+
+  // パターンとして使う．
+  // 特定の文字列操作 (例えば substr, indexof, replace) であるかどうか判定する．
+  // (substr _ _ _) -(unapply)-> StringSort
+  val WithSort = {
+    val lift: Operation => PartialFunction[Terms.Term, Terms.Sort] = op => {
+      case t if op.extractable(t) => op.rangeSort
+    }
+    val ops: PartialFunction[Terms.Term, Terms.Sort] = builtins.map(lift).reduce(_ orElse _)
+    ops orElse strOps
+  }
+
+  // 文字列操作や整数演算以外の項に対して呼び出すとマッチエラー
+  val freeVars: Terms.Term => Set[String] = {
+    def aux(ts: Seq[Terms.Term]): Seq[String] = ts flatMap {
+      // base case
+      case SimpleQualID(s)                => Seq(s)
+      case SNumeral(_) | Terms.SString(_) => Seq()
+      // int operations
+      case Ints.Add(t1, t2) => aux(Seq(t1, t2))
+      case Ints.Sub(t1, t2) => aux(Seq(t1, t2))
+      case Ints.Mul(t1, t2) => aux(Seq(t1, t2))
+      // string-valued
+      case Strings.Concat(ts @ _*)        => aux(ts)
+      case Strings.At(t1, t2)             => aux(Seq(t1, t2))
+      case Strings.Replace(t1, t2, t3)    => aux(Seq(t1, t2, t3))
+      case Strings.Substring(t1, t2, t3)  => aux(Seq(t1, t2, t3))
+      case Strings.ReplaceAll(t1, t2, t3) => aux(Seq(t1, t2, t3))
+      // int-valued
+      case Strings.Length(t)           => aux(Seq(t))
+      case Strings.CountChar(t1, t2)   => aux(Seq(t1, t2))
+      case Strings.IndexOf(t1, t2, t3) => aux(Seq(t1, t2))
+      case Strings.CodeAt(t1, t2)      => aux(Seq(t1, t2))
+      //
+      case _ => throw new MatchError(ts)
+    }
+    term => aux(Seq(term)).toSet
+  }
+
+//  val strVars: PartialFunction[Terms.Term, Set[String]]
+
 }
 
 trait IntValuedOperation extends Operation {

--- a/src/main/scala/Preprocessor.scala
+++ b/src/main/scala/Preprocessor.scala
@@ -5,6 +5,7 @@ import smtlib.theories.Ints
 import smtlib.theories.Core
 import com.github.kmn4.expresso.smttool._
 import com.github.kmn4.expresso.math.Presburger
+import smtlib.trees.Tree
 
 // PyEx 用
 // SMT-LIB コマンド列の変換
@@ -12,12 +13,7 @@ class Preprocessor(operations: Seq[Operation]) {
 
   val provider = StdProvider
 
-  private class Flattener(
-      // パターンとして使う．
-      // 特定の文字列操作 (例えば substr, indexof, replace) であるかどうか判定する．
-      // (substr _ _ _) -(unapply)-> StringSort
-      StringOp: PartialFunction[Terms.Term, Terms.Sort]
-  ) {
+  private class Flattener {
     // あらゆるメソッド呼び出しで registerSort が呼ばれる点に注意
 
     private val sorts = SortStore()
@@ -31,22 +27,38 @@ class Preprocessor(operations: Seq[Operation]) {
     // (replace (replace x y z) w (substr x i j)) のような項を
     // (replace x1 w x2), ((x1, (replace x y z)), (x2, (substr x i j)))
     // のように変形する
-    private val flatTermBinder = new BottomUpTermTransformer {
-      type R = Seq[(String, Terms.Term)]
+    private object FlatTermBinder extends DownUpTermTransformer {
 
-      override def combine(results: Seq[R]): R = results.flatten
+      type C = Set[String] // quantifiedVars
+      type R = Seq[(String, Terms.Term)] // (lhsVar, assignedTerm)
 
-      override def post(term: Terms.Term, result: R): (Terms.Term, R) =
+      override def combine(tree: Tree, context: C, results: Seq[R]): R = results.flatten
+
+      override def down(term: Terms.Term, context: C): C =
+        context ++ quantifiedVars.applyOrElse(term, (_: Terms.Term) => Nil)
+
+      override def up(term: Terms.Term, context: C, result: R): (Terms.Term, R) =
         term match {
-          case StringOp(sort) if result.isEmpty =>
+          case Operation.WithSort(sort) if result.isEmpty /* 一番内側のときだけ */ =>
+            if ((context & Operation.freeVars(term)).nonEmpty)
+              throw new Exception("a string operation argument is quantified")
             val x = provider.freshTemp()
             registerSort(x, sort)
             (SimpleQualID(x), Seq((x, term)))
           case _ => (term, result)
         }
+
+      private val quantifiedVars: PartialFunction[Terms.Term, Seq[String]] = {
+        case Terms.Forall(sv, svs, _) => (sv +: svs) map sortedVar2Pair
+        case Terms.Exists(sv, svs, _) => (sv +: svs) map sortedVar2Pair
+      }
+      private val sortedVar2Pair: Terms.SortedVar => String = {
+        case Terms.SortedVar(Terms.SSymbol(name), _) => name
+      }
+
     }
 
-    private def bindInnermostFlatTerms(term: Terms.Term) = flatTermBinder.transform(term, ())
+    private def bindInnermostFlatTerms(term: Terms.Term) = FlatTermBinder.transform(term, Set())
 
     // f が必ずしも (A => B, A => Seq[C]) へと分解できない場合に使う
     def mapAndFlatMap[A, B, C](f: A => (B, Seq[C])): Seq[A] => (Seq[B], Seq[C]) =
@@ -110,10 +122,10 @@ class Preprocessor(operations: Seq[Operation]) {
         Seq[Terms.Term], // x = y, x = w, i + j < c など (リテラル)
         Map[String, Terms.Sort] // このメソッドで新たに導入した変数のソート
     ) = {
-      val (opsAssigns, opsFlattened) = flattenOps(terms)
+      val (opsAssigns, opsFlattened) = flattenOps(terms) // 文字列値／整数値関数の追い出し
       val flattenAssigns = (_: Seq[(String, Terms.Term)]) flatMap {
         case (x, t) =>
-          val (flattened, arithAssigns) = flattenArith(t)
+          val (flattened, arithAssigns) = flattenArith(t) // 整数演算 (+, -, *) の追い出し
           (x, flattened) +: arithAssigns
       }
       val assigns = flattenAssigns(opsAssigns)
@@ -139,18 +151,7 @@ class Preprocessor(operations: Seq[Operation]) {
     private val flattenArith = (term: Terms.Term) => FlattenArith.transform(term, Nil)
   }
   private[expresso] val flatten = {
-    val strOps: PartialFunction[Terms.Term, Terms.Sort] = {
-      case Strings.Concat(_*)          => Strings.StringSort()
-      case Strings.At(_, _)            => Strings.StringSort()
-      case Strings.Replace(_, _, _)    => Strings.StringSort()
-      case Strings.Substring(_, _, _)  => Strings.StringSort()
-      case Strings.ReplaceAll(_, _, _) => Strings.StringSort()
-    }
-    val lift: Operation => PartialFunction[Terms.Term, Terms.Sort] = op => {
-      case t if op.extractable(t) => op.rangeSort
-    }
-    val ops: PartialFunction[Terms.Term, Terms.Sort] = operations.map(lift).reduce(_ orElse _)
-    val flattener = new Flattener(ops orElse strOps)
+    val flattener = new Flattener
     (terms: Seq[Terms.Term]) => flattener.flatten(terms)
   }
 
@@ -291,7 +292,7 @@ class Preprocessor(operations: Seq[Operation]) {
     val (assigns, literals, newSorts) = flatten(bools)
     newSorts.foreach { case (name, sort) => sorts.register(name, sort) }
 
-    val lhsVars = assigns.iterator.map { case (x, _) => x }.toSet
+    val lhsVars = assigns.iterator.map { case (x, _) => x }.toSet // 整数変数も含む
     // literals の内 x = y (文字列変数の等式) が冗長．
     // 1. 等式から文字列変数の同値類を構成する．
     //    同値類に含まれる左辺変数は高々1つでなければならない (直線性より)．
@@ -310,6 +311,7 @@ class Preprocessor(operations: Seq[Operation]) {
       { case SimpleQualID(name) if sortsMap(name) == string => name }
     }
     // 1., 2.
+    // ここで文字列変数しか考えていないので、uf は整数変数の同値類を作らない
     for (Core.Equals(StringVariable(x), StringVariable(y)) <- literals) {
       uf.make(x)
       uf.make(y)

--- a/src/main/scala/Preprocessor.scala
+++ b/src/main/scala/Preprocessor.scala
@@ -129,7 +129,7 @@ class Preprocessor(operations: Seq[Operation]) {
       def combine(results: Seq[R]): R = results.flatten
 
       def pre(term: Terms.Term, context: C /* この context は Nil のはず */ ): (Terms.Term, C) = term match {
-        case Ints.Neg(_) | SimpleApp("+", _) | Ints.Sub(_, _) | Ints.Mul(Terms.SNumeral(_), _) =>
+        case Ints.Neg(_) | SimpleApp("+", _) | Ints.Sub(_, _) | Ints.Mul(_, _) | Ints.Mod(_, _) =>
           val i = StdProvider.freshTemp()
           registerSort(i, Ints.IntSort())
           (SimpleQualID(i), Seq((i, term)))

--- a/src/main/scala/Solver.scala
+++ b/src/main/scala/Solver.scala
@@ -233,6 +233,7 @@ class Solver(
       case SimpleApp("+", ts) => Presburger.Add(ts.map(linearExp))
       case Ints.Sub(t1, t2)   => Presburger.Sub(linearExp(t1), linearExp(t2))
       case Ints.Mul(c, t)     => Presburger.Mult(linearExp(c), linearExp(t))
+      case Ints.Mod(t1, t2)   => Presburger.Mod(linearExp(t1), linearExp(t2))
     }
     val flatApp: PartialFunction[SMTTerm, (String, ParikhConstraint)] =
       intOps.map(_.expectInt).reduce(_ orElse _)

--- a/src/main/scala/smttool/package.scala
+++ b/src/main/scala/smttool/package.scala
@@ -149,6 +149,23 @@ package object smttool {
     }
   }
 
+  abstract class TermTransformerUsingBoundVars extends DownUpTermTransformer {
+
+    type C = Set[String] // bound variables
+
+    override def down(term: Terms.Term, context: C): C =
+      context ++ quantifiedVars.applyOrElse(term, (_: Terms.Term) => Nil)
+
+    private val quantifiedVars: PartialFunction[Terms.Term, Seq[String]] = {
+      case Terms.Forall(sv, svs, _) => (sv +: svs) map sortedVar2Pair
+      case Terms.Exists(sv, svs, _) => (sv +: svs) map sortedVar2Pair
+    }
+    private val sortedVar2Pair: Terms.SortedVar => String = { case Terms.SortedVar(Terms.SSymbol(name), _) =>
+      name
+    }
+
+  }
+
   abstract class BottomUpTermTransformer extends PrePostTermTransformer {
 
     type C = Unit

--- a/src/main/scala/smttool/package.scala
+++ b/src/main/scala/smttool/package.scala
@@ -124,7 +124,32 @@ package object smttool {
     }
   }
 
-  abstract class BottomUpTermTransformer extends PrePostTreeTransformer {
+  abstract class PrePostTermTransformer extends PrePostTreeTransformer {
+
+    final override def pre(sort: Terms.Sort, context: C): (Terms.Sort, C) =
+      (sort, context)
+
+    final override def post(sort: Terms.Sort, result: R): (Terms.Sort, R) =
+      (sort, result)
+
+  }
+
+  abstract class DownUpTermTransformer extends TreeTransformer {
+
+    /** 結果が transform の再帰呼び出しに渡される */
+    def down(term: Term, context: C): C
+
+    /** サブタームの transform とその結果の combine 後に呼び出されて、term の変換をする */
+    def up(term: Term, context: C, result: R): (Term, R)
+
+    override def transform(term: Term, context: C): (Term, R) = {
+      val downContext = down(term, context)
+      val (upTerm, upResult) = super.transform(term, downContext)
+      up(upTerm, context, upResult)
+    }
+  }
+
+  abstract class BottomUpTermTransformer extends PrePostTermTransformer {
 
     type C = Unit
 
@@ -135,27 +160,15 @@ package object smttool {
 
     final override def pre(term: Term, context: C): (Term, C) = (term, context)
 
-    final override def pre(sort: Terms.Sort, context: C): (Terms.Sort, C) =
-      (sort, context)
-
-    final override def post(sort: Terms.Sort, result: R): (Terms.Sort, R) =
-      (sort, result)
-
   }
 
-  abstract class TopDownTransformer extends PrePostTreeTransformer {
+  abstract class TopDownTransformer extends PrePostTermTransformer {
     type C = R
 
     def combine(results: Seq[R]): R
 
     final override def combine(tree: Tree, context: C, results: Seq[R]): R =
       combine(context +: results)
-
-    final override def pre(sort: Terms.Sort, context: C): (Terms.Sort, C) =
-      (sort, context)
-
-    final override def post(sort: Terms.Sort, result: R): (Terms.Sort, R) =
-      (sort, result)
 
     def post(term: Term, result: R): (Term, R) = (term, result)
 

--- a/src/test/scala/ParikhSolverTest.scala
+++ b/src/test/scala/ParikhSolverTest.scala
@@ -390,6 +390,10 @@ trait ConstraintTestCases extends TestsSAT {
     assert(w == y ++ z)
   }
 
+  testFileSAT("forall") { (sm, _) =>
+    assert(sm("x") == "aaa")
+  }
+
 }
 
 class JSSST2021StrategyTest extends AnyFunSuite with ConstraintTestCases with UsesJSSST

--- a/src/test/scala/ParikhSolverTest.scala
+++ b/src/test/scala/ParikhSolverTest.scala
@@ -390,9 +390,10 @@ trait ConstraintTestCases extends TestsSAT {
     assert(w == y ++ z)
   }
 
-  testFileSAT("forall") { (sm, _) =>
-    assert(sm("x") == "aaa")
-  }
+  testFileSAT("forall") { (sm, _) => assert(sm("x") == "aaa") }
+
+  testFileUNSAT("test-forall-1")
+  testFileUNSAT("test-forall-2")
 
 }
 

--- a/src/test/scala/ParikhSolverTest.scala
+++ b/src/test/scala/ParikhSolverTest.scala
@@ -395,6 +395,25 @@ trait ConstraintTestCases extends TestsSAT {
   testFileUNSAT("test-forall-1")
   testFileUNSAT("test-forall-2")
 
+  val primes = {
+    def sieve(l: LazyList[Int]): LazyList[Int] = {
+      val hd = l.head
+      lazy val tl = sieve(l.tail.filterNot(_ % hd == 0))
+      hd #:: tl
+    }
+    sieve(LazyList.from(2))
+  }
+
+  def isPrime(n: Int): Boolean = primes.dropWhile(_ < n).head == n
+
+  // testFileSAT("prime-sat") { (sm, _) =>
+  //   val x = sm("x")
+  //   val l = x.length
+  //   assert(isPrime(l), s"length of x was non-prime number $l")
+  //   assert(l > 7)
+  //   assert(x.matches("(ab)+a"))
+  // }
+
 }
 
 class JSSST2021StrategyTest extends AnyFunSuite with ConstraintTestCases with UsesJSSST


### PR DESCRIPTION
次を扱えるようにする。

```smt2
;; l が素数
(assert (> l 0))
(assert (forall ((i Int)) (=> (and (> i 1) (< i l)) (> (mod l i) 0))))
```

ただし、次の単純な例でも手元では 10 分かけても判定が終わらなかった。

```smt2
(declare-const x String)
(declare-const l Int)

;; length of x is prime
(assert (forall ((i Int)) (=> (and (> i 1) (< i l)) (> (mod l i) 0))))
(assert (> l 1))
(assert (= (str.len x) l))

(check-sat)
(get-model)
```

次のように、文字列変数が全称量化子の内側にある場合は依然として扱えない。

```smt2
;; x = y
(assert (forall ((i Int)) (= (str.code_at x i) (str.code_at y i))))
```