### PR TITLE
コマンドライン引数の追加と decline によるパース

### DIFF
--- a/.scalafmt.conf
+++ b/.scalafmt.conf
@@ -1,2 +1,5 @@
-version = "2.4.2"
+version = "3.0.6"
 maxColumn = 110
+runner.dialect = "scala213"
+trailingCommas = preserve
+align.preset = more

--- a/build.sbt
+++ b/build.sbt
@@ -8,7 +8,8 @@ libraryDependencies ++= Seq(
   "org.scalatest" %% "scalatest" % "3.1.0" % "test",
   "com.typesafe.scala-logging" %% "scala-logging" % "3.9.2",
   "ch.qos.logback" % "logback-classic" % "1.2.3",
-  "com.regblanc" %% "scala-smtlib" % "0.2.1-42-gc68dbaa"
+  "com.regblanc" %% "scala-smtlib" % "0.2.1-42-gc68dbaa",
+  "com.monovore" %% "decline" % "2.2.0",
 )
 
 scalacOptions ++= Seq(

--- a/constraints/bench/forall.smt2
+++ b/constraints/bench/forall.smt2
@@ -1,0 +1,10 @@
+(declare-const x String)
+
+(assert (forall ((i Int)) (=> (< i 3) (< i (str.len x)))))
+(assert (forall ((i Int)) (=> (> i 3) (> i (str.len x)))))
+;; (assert (forall ((i Int)) (= (str.code_at x (+ i 1)) 97))) ; should raise an exception
+
+(assert (str.in.re x (re.+ (str.to.re "a"))))
+
+(check-sat)
+(get-model)

--- a/constraints/bench/prime-sat.smt2
+++ b/constraints/bench/prime-sat.smt2
@@ -1,0 +1,12 @@
+(declare-const x String)
+(declare-const l Int)
+
+;; length of x is prime
+(assert (forall ((i Int)) (=> (and (> i 1) (< i l)) (> (mod l i) 0))))
+(assert (= (str.len x) l))
+(assert (> l 7))
+
+(assert (str.in.re x (re.++ (re.+ (str.to.re "ab")) (str.to.re "a"))))
+
+(check-sat)
+(get-model)

--- a/constraints/bench/test-forall-1.smt2
+++ b/constraints/bench/test-forall-1.smt2
@@ -1,0 +1,4 @@
+(declare-const x Int)
+(declare-const y String)
+(assert (forall ((x Int)) (= x 0)))
+(check-sat)

--- a/constraints/bench/test-forall-2.smt2
+++ b/constraints/bench/test-forall-2.smt2
@@ -1,0 +1,6 @@
+(declare-const x String)
+(declare-const i Int)
+
+(assert (forall ((ui Int)) (= ui i)))
+
+(check-sat)

--- a/src/main/scala/Main.scala
+++ b/src/main/scala/Main.scala
@@ -1,36 +1,103 @@
 package com.github.kmn4.expresso
 
+import cats.data.Validated
+import cats.data.ValidatedNel
+import ch.qos.logback.{classic => logback}
+import com.github.kmn4.expresso.strategy.JSSST2021Strategy
 import com.github.kmn4.expresso.strategy.PreImageStrategy
+import com.microsoft.z3.Version
+import com.monovore.decline.CommandApp
+import com.typesafe.scalalogging.Logger
 
 import java.nio.file.FileSystems
-import com.typesafe.scalalogging.Logger
-import com.github.kmn4.expresso.strategy.JSSST2021Strategy
+import java.nio.file.Path
 
-// command line arguments:
-// - 0 : constraint file name (.smt2 file)
-// - 1 : solving strategy, either 'preimage' or 'jssst' (defaults to 'jssst')
-object Main extends App {
-  val fname = args(0)
-  val logger = Logger(s"bench.${fname.split('/').last.split('.').dropRight(1).mkString}")
-  val path = FileSystems.getDefault().getPath(fname)
-  val lexer = new smtlib.lexer.Lexer(new java.io.FileReader(path.toFile()))
-  val parser = new smtlib.parser.Parser(lexer)
-  val script = parser.parseScript
-  val checker = args.applyOrElse(1, (_: Int) => "jssst") match {
-    case "preimage" => new PreImageStrategy(logger)
-    case "jssst"   => new JSSST2021Strategy(logger)
-    case s          => throw new Exception(s"Invalid strategy: ${s}\nPossible values are: preimage, jssst")
+object Main
+    extends CommandApp(
+      name = "expresso",
+      header = "Solve straight-line string constraints.",
+      version = s"SNAPSHOT (with ${Version.getFullVersion()})",
+      main = Options.opts map { arguments =>
+        val path   = arguments.constraintFile
+        val file   = path.toFile()
+        val logger = Logger(s"bench.${file.getName().split('.').dropRight(1).mkString}")
+        arguments.loggingLevel map Options.loggingLevels foreach
+          logger.underlying.asInstanceOf[logback.Logger].setLevel
+        val parser   = new smtlib.parser.Parser(new smtlib.lexer.Lexer(new java.io.FileReader(file)))
+        val script   = parser.parseScript                 // might throw an exception
+        val checker  = Options.strategies(arguments.strategyName)(logger)
+        val alphabet = arguments.alphabet getOrElse Set() // alpahbet to be added
+
+        logger.trace(s"checker=$checker")
+        logger.trace(s"logger=$logger")
+        logger.trace(s"alphabet=$alphabet")
+
+        new Solver(
+          checker = checker,
+          print = true,
+          logger = logger,
+          alphabet = alphabet
+        ).executeScript(script)
+      }
+    )
+
+private final case class Arguments(
+    constraintFile: Path,
+    strategyName: String,
+    alphabet: Option[Set[Char]],
+    loggingLevel: Option[String],
+)
+
+private object Options {
+  import com.monovore.decline._
+  import cats.implicits._
+
+  def opts: Opts[Arguments] = (constraintFile, strategy, alphabet, loggingLevel) mapN Arguments.apply
+
+  val strategies = Map(
+    "jssst"    -> (logger => new JSSST2021Strategy(logger)),
+    "preimage" -> (logger => new PreImageStrategy(logger)),
+  )
+
+  val loggingLevels = scala.collection.immutable.SeqMap(
+    "all"   -> logback.Level.TRACE,
+    "trace" -> logback.Level.TRACE,
+    "debug" -> logback.Level.DEBUG,
+    "info"  -> logback.Level.INFO,
+    "warn"  -> logback.Level.WARN,
+    "error" -> logback.Level.ERROR,
+    "off"   -> logback.Level.OFF,
+  )
+
+  val constraintFile = Opts
+    .argument[Path](metavar = "constraint file")
+    .validate("<constraint file> should exist")(_.toFile().exists())
+  val strategy = Opts
+    .argument[String]("strategy")
+    .withDefault("jssst")
+    .validate("<strategy> must be either \"preimage\" or \"jssst\"")(strategies.keySet.contains)
+  val loggingLevel = {
+    val keys   = loggingLevels.keys
+    val msg    = s"one of ${keys.init.mkString(", ")}, or ${keys.last}"
+    val keySet = keys.toSet
+    Opts
+      .option[String]("logging-level", help = msg)
+      .validate(s"<logging-level> must be $msg")(keySet.contains)
+      .orNone
   }
+  val alphabet = Opts
+    .option[Set[Char]](
+      "alphabet",
+      help = "alphabet to be considered additionally to those contained in a given constraint"
+    )(new Argument[Set[Char]] {
+      def read(string: String): ValidatedNel[String, Set[Char]] = string.split("-").toSeq match {
+        case Seq(from, to) if from.length() == 1 && to.length() == 1 =>
+          Validated.valid((from(0) to to(0)).toSet[Char])
+        case _ => Validated.invalidNel("argument to --alphabet must be in the form <char>-<char>")
+      }
 
-  // alpahbet to be added
-  val alphabet = ('a' to 'c').toSet
-//  val alphabet = ('!' to '~').toSet
-//  val alphabet = (0 to 127).toSet
+      def defaultMetavar: String = "alphabet"
+    })
+    .orNone
 
-  new Solver(
-    checker = checker,
-    print = true,
-    logger = logger,
-    alphabet = alphabet
-  ).executeScript(script)
 }

--- a/src/main/scala/Operation.scala
+++ b/src/main/scala/Operation.scala
@@ -54,6 +54,7 @@ object Operation {
       case Ints.Add(t1, t2) => aux(Seq(t1, t2))
       case Ints.Sub(t1, t2) => aux(Seq(t1, t2))
       case Ints.Mul(t1, t2) => aux(Seq(t1, t2))
+      case Ints.Mod(t1, t2) => aux(Seq(t1, t2))
       // string-valued
       case Strings.Concat(ts @ _*)        => aux(ts)
       case Strings.At(t1, t2)             => aux(Seq(t1, t2))

--- a/src/main/scala/Operation.scala
+++ b/src/main/scala/Operation.scala
@@ -11,6 +11,7 @@ import com.github.kmn4.expresso.smttool.Strings
 import smtlib.theories.Ints
 import smtlib.trees.Terms
 import smtlib.trees.Terms.SNumeral
+import com.github.kmn4.expresso.smttool.BottomUpTermTransformer
 
 // Parikh オートマトンや Parikh SST で表して扱う文字列操作．
 sealed trait Operation {
@@ -22,6 +23,56 @@ sealed trait Operation {
 
 object Operation {
   val builtins: Seq[Operation] = IntValuedOperation.builtins ++ StringValuedOperation.builtins
+
+  private val strOps: PartialFunction[Terms.Term, Terms.Sort] = {
+    case Strings.Concat(_*)          => Strings.StringSort()
+    case Strings.At(_, _)            => Strings.StringSort()
+    case Strings.Replace(_, _, _)    => Strings.StringSort()
+    case Strings.Substring(_, _, _)  => Strings.StringSort()
+    case Strings.ReplaceAll(_, _, _) => Strings.StringSort()
+  }
+  // まだ StringValuedOperation.builtins が実装されていないので strOps が必要
+
+  // パターンとして使う．
+  // 特定の文字列操作 (例えば substr, indexof, replace) であるかどうか判定する．
+  // (substr _ _ _) -(unapply)-> StringSort
+  val WithSort = {
+    val lift: Operation => PartialFunction[Terms.Term, Terms.Sort] = op => {
+      case t if op.extractable(t) => op.rangeSort
+    }
+    val ops: PartialFunction[Terms.Term, Terms.Sort] = builtins.map(lift).reduce(_ orElse _)
+    ops orElse strOps
+  }
+
+  // 文字列操作や整数演算以外の項に対して呼び出すとマッチエラー
+  val freeVars: Terms.Term => Set[String] = {
+    def aux(ts: Seq[Terms.Term]): Seq[String] = ts flatMap {
+      // base case
+      case SimpleQualID(s)                => Seq(s)
+      case SNumeral(_) | Terms.SString(_) => Seq()
+      // int operations
+      case Ints.Add(t1, t2) => aux(Seq(t1, t2))
+      case Ints.Sub(t1, t2) => aux(Seq(t1, t2))
+      case Ints.Mul(t1, t2) => aux(Seq(t1, t2))
+      // string-valued
+      case Strings.Concat(ts @ _*)        => aux(ts)
+      case Strings.At(t1, t2)             => aux(Seq(t1, t2))
+      case Strings.Replace(t1, t2, t3)    => aux(Seq(t1, t2, t3))
+      case Strings.Substring(t1, t2, t3)  => aux(Seq(t1, t2, t3))
+      case Strings.ReplaceAll(t1, t2, t3) => aux(Seq(t1, t2, t3))
+      // int-valued
+      case Strings.Length(t)           => aux(Seq(t))
+      case Strings.CountChar(t1, t2)   => aux(Seq(t1, t2))
+      case Strings.IndexOf(t1, t2, t3) => aux(Seq(t1, t2))
+      case Strings.CodeAt(t1, t2)      => aux(Seq(t1, t2))
+      //
+      case _ => throw new MatchError(ts)
+    }
+    term => aux(Seq(term)).toSet
+  }
+
+//  val strVars: PartialFunction[Terms.Term, Set[String]]
+
 }
 
 trait IntValuedOperation extends Operation {

--- a/src/main/scala/Preprocessor.scala
+++ b/src/main/scala/Preprocessor.scala
@@ -51,10 +51,9 @@ class Preprocessor(operations: Seq[Operation]) {
     // f が必ずしも (A => B, A => Seq[C]) へと分解できない場合に使う
     def mapAndFlatMap[A, B, C](f: A => (B, Seq[C])): Seq[A] => (Seq[B], Seq[C]) =
       s =>
-        s.foldLeft((Seq.empty[B], Seq.empty[C])) {
-          case ((accB, accC), a) =>
-            val (b, cs) = f(a)
-            (accB :+ b, accC ++ cs)
+        s.foldLeft((Seq.empty[B], Seq.empty[C])) { case ((accB, accC), a) =>
+          val (b, cs) = f(a)
+          (accB :+ b, accC ++ cs)
         }
 
     private val bindInnermost = mapAndFlatMap(bindInnermostFlatTerms)
@@ -69,10 +68,9 @@ class Preprocessor(operations: Seq[Operation]) {
         // 仮定: Iterable[B] は非空で，どの2つの Iterable[B] も共通部分が空
         map: Map[A, Iterable[B]]
     ): (Map[A, B], Map[B, B]) = {
-      map.foldLeft((Map.empty[A, B], Map.empty[B, B])) {
-        case ((accA, accB), (a, bb)) =>
-          val (b, bMap) = chooseRepr(bb)
-          (accA + (a -> b), accB ++ bMap)
+      map.foldLeft((Map.empty[A, B], Map.empty[B, B])) { case ((accA, accB), (a, bb)) =>
+        val (b, bMap) = chooseRepr(bb)
+        (accA + (a -> b), accB ++ bMap)
       }
     }
 
@@ -111,10 +109,9 @@ class Preprocessor(operations: Seq[Operation]) {
         Map[String, Terms.Sort] // このメソッドで新たに導入した変数のソート
     ) = {
       val (opsAssigns, opsFlattened) = flattenOps(terms) // 文字列値／整数値関数の追い出し
-      val flattenAssigns = (_: Seq[(String, Terms.Term)]) flatMap {
-        case (x, t) =>
-          val (flattened, arithAssigns) = flattenArith(t) // 整数演算 (+, -, *) の追い出し
-          (x, flattened) +: arithAssigns
+      val flattenAssigns = (_: Seq[(String, Terms.Term)]) flatMap { case (x, t) =>
+        val (flattened, arithAssigns) = flattenArith(t) // 整数演算 (+, -, *) の追い出し
+        (x, flattened) +: arithAssigns
       }
       val assigns = flattenAssigns(opsAssigns)
       (assigns, opsFlattened, sortMap(assigns.map(_._1)))
@@ -180,8 +177,8 @@ class Preprocessor(operations: Seq[Operation]) {
         val post = Strings.Regex.All()
         Strings.InRegex(t, Strings.Regex.Concat(pre, cr, post))
       case Core.Equals(
-          Strings.At(t1, Ints.Sub(t2, Terms.SNumeral(n))),
-          Terms.SString(c)
+            Strings.At(t1, Ints.Sub(t2, Terms.SNumeral(n))),
+            Terms.SString(c)
           ) if n - 1 >= 0 && c.length == 1 && t1 == t2 /* TODO 効率？ */ =>
         val pre = Strings.Regex.All()
         val cr = Strings.ToRegex(Terms.SString(c))

--- a/src/main/scala/Preprocessor.scala
+++ b/src/main/scala/Preprocessor.scala
@@ -5,6 +5,7 @@ import smtlib.theories.Ints
 import smtlib.theories.Core
 import com.github.kmn4.expresso.smttool._
 import com.github.kmn4.expresso.math.Presburger
+import smtlib.trees.Tree
 
 // PyEx 用
 // SMT-LIB コマンド列の変換
@@ -12,12 +13,7 @@ class Preprocessor(operations: Seq[Operation]) {
 
   val provider = StdProvider
 
-  private class Flattener(
-      // パターンとして使う．
-      // 特定の文字列操作 (例えば substr, indexof, replace) であるかどうか判定する．
-      // (substr _ _ _) -(unapply)-> StringSort
-      StringOp: PartialFunction[Terms.Term, Terms.Sort]
-  ) {
+  private class Flattener {
     // あらゆるメソッド呼び出しで registerSort が呼ばれる点に注意
 
     private val sorts = SortStore()
@@ -31,22 +27,38 @@ class Preprocessor(operations: Seq[Operation]) {
     // (replace (replace x y z) w (substr x i j)) のような項を
     // (replace x1 w x2), ((x1, (replace x y z)), (x2, (substr x i j)))
     // のように変形する
-    private val flatTermBinder = new BottomUpTermTransformer {
-      type R = Seq[(String, Terms.Term)]
+    private object FlatTermBinder extends DownUpTermTransformer {
 
-      override def combine(results: Seq[R]): R = results.flatten
+      type C = Set[String] // quantifiedVars
+      type R = Seq[(String, Terms.Term)] // (lhsVar, assignedTerm)
 
-      override def post(term: Terms.Term, result: R): (Terms.Term, R) =
+      override def combine(tree: Tree, context: C, results: Seq[R]): R = results.flatten
+
+      override def down(term: Terms.Term, context: C): C =
+        context ++ quantifiedVars.applyOrElse(term, (_: Terms.Term) => Nil)
+
+      override def up(term: Terms.Term, context: C, result: R): (Terms.Term, R) =
         term match {
-          case StringOp(sort) if result.isEmpty =>
+          case Operation.WithSort(sort) if result.isEmpty /* 一番内側のときだけ */ =>
+            if ((context & Operation.freeVars(term)).nonEmpty)
+              throw new Exception("a string operation argument is quantified")
             val x = provider.freshTemp()
             registerSort(x, sort)
             (SimpleQualID(x), Seq((x, term)))
           case _ => (term, result)
         }
+
+      private val quantifiedVars: PartialFunction[Terms.Term, Seq[String]] = {
+        case Terms.Forall(sv, svs, _) => (sv +: svs) map sortedVar2Pair
+        case Terms.Exists(sv, svs, _) => (sv +: svs) map sortedVar2Pair
+      }
+      private val sortedVar2Pair: Terms.SortedVar => String = {
+        case Terms.SortedVar(Terms.SSymbol(name), _) => name
+      }
+
     }
 
-    private def bindInnermostFlatTerms(term: Terms.Term) = flatTermBinder.transform(term, ())
+    private def bindInnermostFlatTerms(term: Terms.Term) = FlatTermBinder.transform(term, Set())
 
     // f が必ずしも (A => B, A => Seq[C]) へと分解できない場合に使う
     def mapAndFlatMap[A, B, C](f: A => (B, Seq[C])): Seq[A] => (Seq[B], Seq[C]) =
@@ -110,10 +122,10 @@ class Preprocessor(operations: Seq[Operation]) {
         Seq[Terms.Term], // x = y, x = w, i + j < c など (リテラル)
         Map[String, Terms.Sort] // このメソッドで新たに導入した変数のソート
     ) = {
-      val (opsAssigns, opsFlattened) = flattenOps(terms)
+      val (opsAssigns, opsFlattened) = flattenOps(terms) // 文字列値／整数値関数の追い出し
       val flattenAssigns = (_: Seq[(String, Terms.Term)]) flatMap {
         case (x, t) =>
-          val (flattened, arithAssigns) = flattenArith(t)
+          val (flattened, arithAssigns) = flattenArith(t) // 整数演算 (+, -, *) の追い出し
           (x, flattened) +: arithAssigns
       }
       val assigns = flattenAssigns(opsAssigns)
@@ -139,18 +151,7 @@ class Preprocessor(operations: Seq[Operation]) {
     private val flattenArith = (term: Terms.Term) => FlattenArith.transform(term, Nil)
   }
   private[expresso] val flatten = {
-    val strOps: PartialFunction[Terms.Term, Terms.Sort] = {
-      case Strings.Concat(_*)          => Strings.StringSort()
-      case Strings.At(_, _)            => Strings.StringSort()
-      case Strings.Replace(_, _, _)    => Strings.StringSort()
-      case Strings.Substring(_, _, _)  => Strings.StringSort()
-      case Strings.ReplaceAll(_, _, _) => Strings.StringSort()
-    }
-    val lift: Operation => PartialFunction[Terms.Term, Terms.Sort] = op => {
-      case t if op.extractable(t) => op.rangeSort
-    }
-    val ops: PartialFunction[Terms.Term, Terms.Sort] = operations.map(lift).reduce(_ orElse _)
-    val flattener = new Flattener(ops orElse strOps)
+    val flattener = new Flattener
     (terms: Seq[Terms.Term]) => flattener.flatten(terms)
   }
 
@@ -291,7 +292,7 @@ class Preprocessor(operations: Seq[Operation]) {
     val (assigns, literals, newSorts) = flatten(bools)
     newSorts.foreach { case (name, sort) => sorts.register(name, sort) }
 
-    val lhsVars = assigns.iterator.map { case (x, _) => x }.toSet
+    val lhsVars = assigns.iterator.map { case (x, _) => x }.toSet // 整数変数も含む
     // literals の内 x = y (文字列変数の等式) が冗長．
     // 1. 等式から文字列変数の同値類を構成する．
     //    同値類に含まれる左辺変数は高々1つでなければならない (直線性より)．
@@ -310,6 +311,7 @@ class Preprocessor(operations: Seq[Operation]) {
       { case SimpleQualID(name) if sortsMap(name) == string => name }
     }
     // 1., 2.
+    // ここで文字列変数しか考えていないので、uf は整数変数の同値類を作らない
     for (Core.Equals(StringVariable(x), StringVariable(y)) <- literals) {
       uf.make(x)
       uf.make(y)

--- a/src/main/scala/Preprocessor.scala
+++ b/src/main/scala/Preprocessor.scala
@@ -129,7 +129,7 @@ class Preprocessor(operations: Seq[Operation]) {
       def combine(results: Seq[R]): R = results.flatten
 
       def pre(term: Terms.Term, context: C /* この context は Nil のはず */ ): (Terms.Term, C) = term match {
-        case Ints.Neg(_) | SimpleApp("+", _) | Ints.Sub(_, _) | Ints.Mul(Terms.SNumeral(_), _) =>
+        case Ints.Neg(_) | SimpleApp("+", _) | Ints.Sub(_, _) | Ints.Mul(_, _) | Ints.Mod(_, _) =>
           val i = StdProvider.freshTemp()
           registerSort(i, Ints.IntSort())
           (SimpleQualID(i), Seq((i, term)))

--- a/src/main/scala/Solver.scala
+++ b/src/main/scala/Solver.scala
@@ -233,6 +233,7 @@ class Solver(
       case SimpleApp("+", ts) => Presburger.Add(ts.map(linearExp))
       case Ints.Sub(t1, t2)   => Presburger.Sub(linearExp(t1), linearExp(t2))
       case Ints.Mul(c, t)     => Presburger.Mult(linearExp(c), linearExp(t))
+      case Ints.Mod(t1, t2)   => Presburger.Mod(linearExp(t1), linearExp(t2))
     }
     val flatApp: PartialFunction[SMTTerm, (String, ParikhConstraint)] =
       intOps.map(_.expectInt).reduce(_ orElse _)

--- a/src/main/scala/Solver.scala
+++ b/src/main/scala/Solver.scala
@@ -49,7 +49,7 @@ class Solver(
     alphabet: Set[Char] = Set.empty, // ADDED to the alphabet of constraints
     operations: Seq[Operation] = Operation.builtins
 ) {
-  val intOps = operations.collect { case o: IntValuedOperation    => o }
+  val intOps = operations.collect { case o: IntValuedOperation => o }
   val strOps = operations.collect { case o: StringValuedOperation => o }
 
   type ParikhConstraint = Constraint.ParikhConstraint[String]
@@ -171,7 +171,7 @@ class Solver(
       case SimpleApp("re.comp", Seq(e)) => CompExp(expectRegExp(e))
       case Strings.Regex.AllChar()      => DotExp
       case SimpleQualID("re.all")       => StarExp(DotExp)
-      case _                            => throw new Exception(s"Cannot interpret given S-expression as regular expression: $t")
+      case _ => throw new Exception(s"Cannot interpret given S-expression as regular expression: $t")
     }
 
   type SolverOption = Unit
@@ -210,7 +210,7 @@ class Solver(
           case SString(w)            => w.map(Left.apply)
           case SNumeral(i) if i == 0 => Seq(Right(None))
           case SNumeral(i) if i > 0  => Seq(Right(Some(i.toInt)))
-          case t                     => throw new Exception(s"${t.getPos}: PCRE Replacement component expected but found: $t")
+          case t => throw new Exception(s"${t.getPos}: PCRE Replacement component expected but found: $t")
         }
       )
     case _ => throw new Exception(s"${t.getPos}: PCRE Replacement expected but found: $t")
@@ -316,12 +316,11 @@ class Solver(
       (Ints.GreaterEquals, Presburger.Ge _)
     )
     def unapply(t: SMTTerm): Option[(Presburger.Formula[String], Seq[ParikhConstraint])] = {
-      val binOpt = binary.find { case (op, _) => op.unapply(t).nonEmpty }.map {
-        case (op, constructor) =>
-          val Some((t1, t2)) = op.unapply(t)
-          val (pt1, cs1) = expectInt(t1)
-          val (pt2, cs2) = expectInt(t2)
-          (constructor(pt1, pt2), cs1 ++ cs2)
+      val binOpt = binary.find { case (op, _) => op.unapply(t).nonEmpty }.map { case (op, constructor) =>
+        val Some((t1, t2)) = op.unapply(t)
+        val (pt1, cs1) = expectInt(t1)
+        val (pt2, cs2) = expectInt(t2)
+        (constructor(pt1, pt2), cs1 ++ cs2)
       }
       if (binOpt.nonEmpty) return Some(binOpt.get)
       t match {
@@ -403,7 +402,7 @@ class Solver(
     case SMTCommands.Assert(assertion)                        => assert(assertion)
     case SMTCommands.CheckSat()                               => checkSat()
     case SMTCommands.GetModel()                               => getModel()
-    case _                                                    => throw new Exception(s"${cmd.getPos}: Unsupported command: ${cmd}")
+    case _ => throw new Exception(s"${cmd.getPos}: Unsupported command: ${cmd}")
   }
 
   private def preprocess(commands: Seq[SMTCommands.Command]): Seq[SMTCommands.Command] = {
@@ -453,7 +452,7 @@ class Solver(
         .collect { case a: AtomicAssignment[String] => a.renameVars(varIdx) }
         .sortBy(_.dependerVars.head)
       val assertions = constraints.collect { case a: ParikhAssertion[String] => a.renameVars(varIdx) }
-      val arithFormula = constraints.collect { case PureIntConstraint(f)     => f }
+      val arithFormula = constraints.collect { case PureIntConstraint(f) => f }
       strategy.Input(
         alphabet,
         stringVars.length,
@@ -488,11 +487,10 @@ object PyExEscape extends Escape {
     ('\\', '\\')
   )
   private val backslashes = backslashesSeq
-    .map {
-      case (target, replacement) =>
-        val t = "\\" + target
-        val r = replacement.toString
-        (w: String) => w.replace(t, r)
+    .map { case (target, replacement) =>
+      val t = "\\" + target
+      val r = replacement.toString
+      (w: String) => w.replace(t, r)
     }
   private val func = (Seq(hexCode) ++ backslashes)
     .reduce[String => String] { case (acc, f) => acc andThen f }

--- a/src/main/scala/smttool/package.scala
+++ b/src/main/scala/smttool/package.scala
@@ -149,6 +149,23 @@ package object smttool {
     }
   }
 
+  abstract class TermTransformerUsingBoundVars extends DownUpTermTransformer {
+
+    type C = Set[String] // bound variables
+
+    override def down(term: Terms.Term, context: C): C =
+      context ++ quantifiedVars.applyOrElse(term, (_: Terms.Term) => Nil)
+
+    private val quantifiedVars: PartialFunction[Terms.Term, Seq[String]] = {
+      case Terms.Forall(sv, svs, _) => (sv +: svs) map sortedVar2Pair
+      case Terms.Exists(sv, svs, _) => (sv +: svs) map sortedVar2Pair
+    }
+    private val sortedVar2Pair: Terms.SortedVar => String = { case Terms.SortedVar(Terms.SSymbol(name), _) =>
+      name
+    }
+
+  }
+
   abstract class BottomUpTermTransformer extends PrePostTermTransformer {
 
     type C = Unit

--- a/src/main/scala/smttool/package.scala
+++ b/src/main/scala/smttool/package.scala
@@ -46,20 +46,19 @@ package object smttool {
   val elimDoubleNegation = subst { case Core.Not(Core.Not(t)) => t }
   val elimITE = subst {
     case Core.Equals(
-        Core.ITE(t, Terms.SNumeral(n), Terms.SNumeral(m)),
-        Terms.SNumeral(l)
+          Core.ITE(t, Terms.SNumeral(n), Terms.SNumeral(m)),
+          Terms.SNumeral(l)
         ) =>
       if (n == l && m == l) Core.True()
       else if (n == l) t
       else if (m == l) Core.Not(t)
       else Core.False()
   }
-  val elimAt = subst {
-    case Strings.At(w, i) =>
-      Strings.Substring(w, i, Terms.SNumeral(BigInt(1)))
+  val elimAt = subst { case Strings.At(w, i) =>
+    Strings.Substring(w, i, Terms.SNumeral(BigInt(1)))
   }
-  def compose[A](f: A => A*): A => A = f.foldLeft[A => A](identity) {
-    case (acc, f) => acc andThen f
+  def compose[A](f: A => A*): A => A = f.foldLeft[A => A](identity) { case (acc, f) =>
+    acc andThen f
   }
   val simplify: Term => Term = compose(elimITE, elimDoubleNegation, elimAt)
 

--- a/src/main/scala/smttool/package.scala
+++ b/src/main/scala/smttool/package.scala
@@ -124,7 +124,32 @@ package object smttool {
     }
   }
 
-  abstract class BottomUpTermTransformer extends PrePostTreeTransformer {
+  abstract class PrePostTermTransformer extends PrePostTreeTransformer {
+
+    final override def pre(sort: Terms.Sort, context: C): (Terms.Sort, C) =
+      (sort, context)
+
+    final override def post(sort: Terms.Sort, result: R): (Terms.Sort, R) =
+      (sort, result)
+
+  }
+
+  abstract class DownUpTermTransformer extends TreeTransformer {
+
+    /** 結果が transform の再帰呼び出しに渡される */
+    def down(term: Term, context: C): C
+
+    /** サブタームの transform とその結果の combine 後に呼び出されて、term の変換をする */
+    def up(term: Term, context: C, result: R): (Term, R)
+
+    override def transform(term: Term, context: C): (Term, R) = {
+      val downContext = down(term, context)
+      val (upTerm, upResult) = super.transform(term, downContext)
+      up(upTerm, context, upResult)
+    }
+  }
+
+  abstract class BottomUpTermTransformer extends PrePostTermTransformer {
 
     type C = Unit
 
@@ -135,27 +160,15 @@ package object smttool {
 
     final override def pre(term: Term, context: C): (Term, C) = (term, context)
 
-    final override def pre(sort: Terms.Sort, context: C): (Terms.Sort, C) =
-      (sort, context)
-
-    final override def post(sort: Terms.Sort, result: R): (Terms.Sort, R) =
-      (sort, result)
-
   }
 
-  abstract class TopDownTransformer extends PrePostTreeTransformer {
+  abstract class TopDownTransformer extends PrePostTermTransformer {
     type C = R
 
     def combine(results: Seq[R]): R
 
     final override def combine(tree: Tree, context: C, results: Seq[R]): R =
       combine(context +: results)
-
-    final override def pre(sort: Terms.Sort, context: C): (Terms.Sort, C) =
-      (sort, context)
-
-    final override def post(sort: Terms.Sort, result: R): (Terms.Sort, R) =
-      (sort, result)
 
     def post(term: Term, result: R): (Term, R) = (term, result)
 

--- a/src/test/scala/ParikhSolverTest.scala
+++ b/src/test/scala/ParikhSolverTest.scala
@@ -390,6 +390,10 @@ trait ConstraintTestCases extends TestsSAT {
     assert(w == y ++ z)
   }
 
+  testFileSAT("forall") { (sm, _) =>
+    assert(sm("x") == "aaa")
+  }
+
 }
 
 class JSSST2021StrategyTest extends AnyFunSuite with ConstraintTestCases with UsesJSSST

--- a/src/test/scala/ParikhSolverTest.scala
+++ b/src/test/scala/ParikhSolverTest.scala
@@ -390,9 +390,10 @@ trait ConstraintTestCases extends TestsSAT {
     assert(w == y ++ z)
   }
 
-  testFileSAT("forall") { (sm, _) =>
-    assert(sm("x") == "aaa")
-  }
+  testFileSAT("forall") { (sm, _) => assert(sm("x") == "aaa") }
+
+  testFileUNSAT("test-forall-1")
+  testFileUNSAT("test-forall-2")
 
 }
 

--- a/src/test/scala/ParikhSolverTest.scala
+++ b/src/test/scala/ParikhSolverTest.scala
@@ -395,6 +395,25 @@ trait ConstraintTestCases extends TestsSAT {
   testFileUNSAT("test-forall-1")
   testFileUNSAT("test-forall-2")
 
+  val primes = {
+    def sieve(l: LazyList[Int]): LazyList[Int] = {
+      val hd = l.head
+      lazy val tl = sieve(l.tail.filterNot(_ % hd == 0))
+      hd #:: tl
+    }
+    sieve(LazyList.from(2))
+  }
+
+  def isPrime(n: Int): Boolean = primes.dropWhile(_ < n).head == n
+
+  // testFileSAT("prime-sat") { (sm, _) =>
+  //   val x = sm("x")
+  //   val l = x.length
+  //   assert(isPrime(l), s"length of x was non-prime number $l")
+  //   assert(l > 7)
+  //   assert(x.matches("(ab)+a"))
+  // }
+
 }
 
 class JSSST2021StrategyTest extends AnyFunSuite with ConstraintTestCases with UsesJSSST

--- a/src/test/scala/ParikhSolverTest.scala
+++ b/src/test/scala/ParikhSolverTest.scala
@@ -281,13 +281,12 @@ trait ConstraintTestCases extends TestsSAT {
 (assert (str.in.re y (re.comp (str.to.re "ab"))))
 
 (check-sat)
-""") {
-    case (sModel, iModel) =>
-      val (x, y, i) = (sModel("x"), sModel("y"), iModel("i"))
-      assert("(ab)+".r.matches(x))
-      assert(0 <= i && i < x.length)
-      assert(y == x.atmostSubstring(i, 2))
-      assert(!"ab".r.matches(y))
+""") { case (sModel, iModel) =>
+    val (x, y, i) = (sModel("x"), sModel("y"), iModel("i"))
+    assert("(ab)+".r.matches(x))
+    assert(0 <= i && i < x.length)
+    assert(y == x.atmostSubstring(i, 2))
+    assert(!"ab".r.matches(y))
   }
 
   testSAT(""";; Bug fixed on 2021-07-05


### PR DESCRIPTION
`sbt assembly && java -jar target/scala-2.13/expresso-assembly-0.3.0-SNAPSHOT.jar --help`

```
Usage: expresso [--alphabet <alphabet>] [--logging-level <string>] <constraint file> [<strategy>]

Solve straight-line string constraints.

Options and flags:
    --help
        Display this help text.
    --version
        Print the version number and exit.
    --alphabet <alphabet>
        alphabet to be considered additionally to those contained in a given constraint
    --logging-level <string>
        one of all, trace, debug, info, warn, error, or off
```

[decline](https://github.com/bkirwi/decline) を使っている